### PR TITLE
fix deadlink to pipenv docs

### DIFF
--- a/pipenv/README.md
+++ b/pipenv/README.md
@@ -61,7 +61,7 @@ $ pipenv shell
 ## Next steps
 
 Congratulations, you now know how to install and use Python packages! ✨ 🍰 ✨
-Next, you can explore the official Pipenv [documentation](https://docs.pipenv.org/).
+Next, you can explore the official Pipenv [documentation](https://pipenv.kennethreitz.org).
 
 If you're interested in what kind of shell is used here, it's fish! You can play with
 it in our [fish shell](https://rootnroll.com/d/fish-shell/) playground.


### PR DESCRIPTION
Went through the rootnroll tutorial today and noticed the official docs link was dead. Super simple fix: change the link to the current documentation, as given in the [Pypa pipenv repository](https://github.com/pypa/pipenv/).

It appears that the official documentation lives at https://pipenv.kennethreitz.org.