### PR TITLE
Update Pipenv documentation link - existing link now hosted by scammers

### DIFF
--- a/pipenv/README.md
+++ b/pipenv/README.md
@@ -61,7 +61,7 @@ $ pipenv shell
 ## Next steps
 
 Congratulations, you now know how to install and use Python packages! ✨ 🍰 ✨
-Next, you can explore the official Pipenv [documentation](https://docs.pipenv.org/).
+Next, you can explore the official Pipenv [documentation](https://pipenv.pypa.io/).
 
 If you're interested in what kind of shell is used here, it's fish! You can play with
 it in our [fish shell](https://rootnroll.com/d/fish-shell/) playground.


### PR DESCRIPTION
See https://github.com/pypa/pipenv/issues/4671 for details.

Paging @psviderski @ksunden explicitly as this repo seems quiet.

Replaces #5 which is out of date, fixes #4 